### PR TITLE
fix: derive runtime API base to prevent login 502

### DIFF
--- a/xmoker-app/src/environments/environment.prod.ts
+++ b/xmoker-app/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
+const host = typeof window !== 'undefined' ? window.location.origin : '';
+
 export const environment = {
   production: true,
-  apiUrl: '/api'
+  apiUrl: `${host}/api`
 };


### PR DESCRIPTION
## Summary
- derive production API base URL from `window.location.origin` to avoid proxying errors

## Testing
- `npm install --force` *(fails: 403 Forbidden fetching @angular/cdk)*
- `mvn -q -f xmoker-backend/xmoker-backend/pom.xml test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a600dfb150832999b93e09e01cff01